### PR TITLE
Secure endpoints to create, edit, and delete announcements

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,12 +23,10 @@ def authenticate(f):
     @wraps(f)
     def inner(*args, **kwargs):
         auth_header = request.headers.get("Authorization")
-        if auth_header is None:
+        if not auth_header:
             return constants.MISSING_REQUEST_TOKEN_ERROR
         bearer_token = auth_header.replace("Bearer ", "").strip()
-        if not bearer_token:
-            return constants.INVALID_REQUEST_TOKEN_ERROR
-        if bearer_token != environ["TOKEN"]:
+        if not bearer_token or bearer_token != environ["TOKEN"]:
             return constants.INVALID_REQUEST_TOKEN_ERROR
         return f(*args, **kwargs)
 

--- a/app.py
+++ b/app.py
@@ -59,7 +59,6 @@ def delete_announcement(id):
 
 
 @app.route("/active/<app>/")
-@authenticate
 def get_announcements(app):
     res = dao.get_announcements(app)
     return res

--- a/app.py
+++ b/app.py
@@ -19,6 +19,8 @@ with app.app_context():
 
 @app.route("/create/", methods=["POST"])
 def create_announcement():
+    if not dao.verify_request(request):
+        return dao.auth_failed()
     post_body = json.loads(request.data)
     res = dao.commit_announcement(post_body)
     return res
@@ -26,6 +28,8 @@ def create_announcement():
 
 @app.route("/update/<id>/", methods=["POST"])
 def update(id):
+    if not dao.verify_request(request):
+        return dao.auth_failed()
     post_body = json.loads(request.data)
     res = dao.update_announcement(post_body, id)
     return res
@@ -33,12 +37,16 @@ def update(id):
 
 @app.route("/delete/<id>/", methods=["DELETE"])
 def delete_announcement(id):
+    if not dao.verify_request(request):
+        return dao.auth_failed()
     res = dao.delete_announcement(id)
     return res
 
 
 @app.route("/active/<app>/")
 def get_announcements(app):
+    if not dao.verify_request(request):
+        return dao.auth_failed()
     res = dao.get_announcements(app)
     return res
 

--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ def authenticate(f):
         if auth_header is None:
             return constants.MISSING_REQUEST_TOKEN_ERROR
         bearer_token = auth_header.replace("Bearer ", "").strip()
-        if bearer_token is None or not bearer_token:
+        if not bearer_token:
             return constants.INVALID_REQUEST_TOKEN_ERROR
         if bearer_token != environ["TOKEN"]:
             return constants.INVALID_REQUEST_TOKEN_ERROR

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 from db import db
 from flask import Flask, request
+from functools import wraps
 from os import environ
+import constants
 import dao
 import json
 
@@ -17,36 +19,48 @@ with app.app_context():
     db.create_all()
 
 
+def authenticate(f):
+    @wraps(f)
+    def inner(*args, **kwargs):
+        auth_header = request.headers.get("Authorization")
+        if auth_header is None:
+            return constants.MISSING_REQUEST_TOKEN_ERROR
+        bearer_token = auth_header.replace("Bearer ", "").strip()
+        if bearer_token is None or not bearer_token:
+            return constants.INVALID_REQUEST_TOKEN_ERROR
+        if bearer_token != environ["TOKEN"]:
+            return constants.INVALID_REQUEST_TOKEN_ERROR
+        return f(*args, **kwargs)
+
+    return inner
+
+
 @app.route("/create/", methods=["POST"])
+@authenticate
 def create_announcement():
-    if not dao.verify_request(request):
-        return dao.auth_failed()
     post_body = json.loads(request.data)
     res = dao.commit_announcement(post_body)
     return res
 
 
 @app.route("/update/<id>/", methods=["POST"])
+@authenticate
 def update(id):
-    if not dao.verify_request(request):
-        return dao.auth_failed()
     post_body = json.loads(request.data)
     res = dao.update_announcement(post_body, id)
     return res
 
 
 @app.route("/delete/<id>/", methods=["DELETE"])
+@authenticate
 def delete_announcement(id):
-    if not dao.verify_request(request):
-        return dao.auth_failed()
     res = dao.delete_announcement(id)
     return res
 
 
 @app.route("/active/<app>/")
+@authenticate
 def get_announcements(app):
-    if not dao.verify_request(request):
-        return dao.auth_failed()
     res = dao.get_announcements(app)
     return res
 

--- a/constants.py
+++ b/constants.py
@@ -5,7 +5,8 @@ INVALID_ANNOUNCEMENT_ID_ERROR = json.dumps({"success": False, "error": "No annou
 INVALID_REQUEST_BODY_ERROR = json.dumps({"success": False, "error": "Invalid request body"})
 SUCCESSFUL_RESPONSE = json.dumps({"success": True})
 INVALID_APP_NAME_ERROR = json.dumps({"success": False, "error": "Invalid app identifier(s)"})
-INVALID_REQUEST_TOKEN = json.dumps({"success": False, "error": "Permission Denied"})
+MISSING_REQUEST_TOKEN_ERROR = json.dumps({"success": False, "error": "Missing access token"})
+INVALID_REQUEST_TOKEN_ERROR = json.dumps({"success": False, "error": "Invalid access token"})
 EDITABLE_ANNOUNCEMENT_FIELDS = [
     "body",
     "cta_action",

--- a/constants.py
+++ b/constants.py
@@ -1,12 +1,13 @@
 import json
 
-INVALID_DATE_ERROR = json.dumps({"success": False, "error": "Please input a valid date of the form 'mm/dd/yyyy'"})
 INVALID_ANNOUNCEMENT_ID_ERROR = json.dumps({"success": False, "error": "No announcement with that id exists"})
-INVALID_REQUEST_BODY_ERROR = json.dumps({"success": False, "error": "Invalid request body"})
-SUCCESSFUL_RESPONSE = json.dumps({"success": True})
 INVALID_APP_NAME_ERROR = json.dumps({"success": False, "error": "Invalid app identifier(s)"})
-MISSING_REQUEST_TOKEN_ERROR = json.dumps({"success": False, "error": "Missing access token"})
+INVALID_DATE_ERROR = json.dumps({"success": False, "error": "Please input a valid date of the form 'mm/dd/yyyy'"})
+INVALID_REQUEST_BODY_ERROR = json.dumps({"success": False, "error": "Invalid request body"})
 INVALID_REQUEST_TOKEN_ERROR = json.dumps({"success": False, "error": "Invalid access token"})
+MISSING_REQUEST_TOKEN_ERROR = json.dumps({"success": False, "error": "Missing access token"})
+SUCCESSFUL_RESPONSE = json.dumps({"success": True})
+
 EDITABLE_ANNOUNCEMENT_FIELDS = [
     "body",
     "cta_action",

--- a/constants.py
+++ b/constants.py
@@ -5,6 +5,7 @@ INVALID_ANNOUNCEMENT_ID_ERROR = json.dumps({"success": False, "error": "No annou
 INVALID_REQUEST_BODY_ERROR = json.dumps({"success": False, "error": "Invalid request body"})
 SUCCESSFUL_RESPONSE = json.dumps({"success": True})
 INVALID_APP_NAME_ERROR = json.dumps({"success": False, "error": "Invalid app identifier(s)"})
+INVALID_REQUEST_TOKEN = json.dumps({"success": False, "error": "Permission Denied"})
 EDITABLE_ANNOUNCEMENT_FIELDS = [
     "body",
     "cta_action",

--- a/dao.py
+++ b/dao.py
@@ -1,7 +1,20 @@
 from db import Announcement, App, db
 from datetime import datetime
+from os import environ
 import constants
 import json
+
+
+def verify_request(request):
+    try:
+        token = request.headers.get("token")
+        return environ["TOKEN"] == token
+    except:
+        return False
+
+
+def auth_failed():
+    return constants.INVALID_REQUEST_TOKEN
 
 
 def get_app_by_name(name):
@@ -97,8 +110,5 @@ def get_announcements(app):
         .filter(Announcement.start_date < datetime.now())
         .all()
     )
-    res = {
-        "success": True,
-        "data": [announcement.serialize() for announcement in active_announcements],
-    }
+    res = {"success": True, "data": [announcement.serialize() for announcement in active_announcements]}
     return json.dumps(res), 200

--- a/dao.py
+++ b/dao.py
@@ -1,20 +1,7 @@
 from db import Announcement, App, db
 from datetime import datetime
-from os import environ
 import constants
 import json
-
-
-def verify_request(request):
-    try:
-        token = request.headers.get("token")
-        return environ["TOKEN"] == token
-    except:
-        return False
-
-
-def auth_failed():
-    return constants.INVALID_REQUEST_TOKEN
 
 
 def get_app_by_name(name):

--- a/envrc.template
+++ b/envrc.template
@@ -1,3 +1,4 @@
 export DB_FILENAME=""
 export PORT=5000
+export TOKEN=""
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

  <!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

 
  ## Overview

  <!-- Summarize your changes here. -->
Add authentication to the endpoints for creating, editing, and deleting announcements.
 
 
  ## Changes Made

  <!-- Include details of what your changes actually are and how it is intended to work. -->
Created an 'authenticate' decorator based off the one found [here](https://github.com/cuappdev/archives/blob/master/register/src/app/eventregister/s/utils/authorize.pyl)

 
 
  ## Test Coverage

  <!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Tested using postman.
 
 
  ## Next Steps 

  <!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
Creating documentation.
 
 
  ## Related PRs or Issues 

  <!-- List related PRs against other branches/repositories. -->
[Issue #6](https://github.com/cuappdev/announcements-backend/issues/6)
 
 
